### PR TITLE
AU-2123: Fix D10 version constraints, alphabetize use statements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "drupal-module",
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "autoload": {
     "psr-4": {
       "Drupal\\HelfiGdprApi\\": "src/"

--- a/helfi_gdpr_api.info.yml
+++ b/helfi_gdpr_api.info.yml
@@ -2,8 +2,7 @@ name: helfi_gdpr_api
 type: module
 description: Implement GDPR api for sites
 package: Helfi
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - helfi_atv
   - helfi_tunnistamo

--- a/src/Controller/HelfiGdprApiController.php
+++ b/src/Controller/HelfiGdprApiController.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_gdpr_api\Controller;
 
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityBase;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultAllowed;
 use Drupal\Core\Access\AccessResultForbidden;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityBase;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Language\ContextProvider\CurrentLanguageContext;
@@ -22,14 +22,14 @@ use Drupal\helfi_atv\AtvService;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\helfi_helsinki_profiili\TokenExpiredException;
 use Drupal\user\Entity\User;
+use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Firebase\JWT\SignatureInvalidException;
-use Firebase\JWT\BeforeValidException;
-use Firebase\JWT\ExpiredException;
 
 /**
  * Returns responses for helfi_gdpr_api routes.


### PR DESCRIPTION
# [AU-2123](https://helsinkisolutionoffice.atlassian.net/browse/AU-2123)

## What was done

## How to install
* Follow instructions in this PR: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241
* Install test branches for all updated modules:
  *  `composer require drupal/helfi_atv:dev-AU-2123-d10-updates drupal/helfi_helsinki_profiili:dev-AU-2123-d10-updates drupal/helfi_yjdh:dev-AU-2123-d10-updates`

## How to test
* [ ] You should no longer get a warning about these incompatible modules when you run `drush updb` for example on the D10 branch
* [ ] Check that code follows our standards
* [ ] Run `make test-pw` just in case

## Automatic- / Regression tests
* [X] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1241

[AU-2123]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ